### PR TITLE
ci: add workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,7 @@ on:
       - main
 
 permissions:
-  contents: 
-    read: true
-    write: true
+  contents: write
   packages: write
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: 
+    read: true
+    write: true
   packages: write
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  packages: write
+
 env:
   node_version: 20
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/johnhwhite/ng-keyboard-sort/security/code-scanning/1](https://github.com/johnhwhite/ng-keyboard-sort/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are likely required:
- `contents: read` for accessing repository contents.
- `contents: write` for creating releases or modifying repository contents.
- `packages: write` for publishing to NPM.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`release-please`) to limit permissions to that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
